### PR TITLE
Fix The directory "[object Object]" not found messages

### DIFF
--- a/tasks/git-svn-checkout.js
+++ b/tasks/git-svn-checkout.js
@@ -59,7 +59,7 @@ module.exports = function (grunt) {
       
       // validate outer directory
       if ( ! grunt.file.isDir( relPath.outer ) ) {
-        grunt.log.warn('The directory "' + relPath + '" not found.');
+        grunt.log.warn('The directory "' + relPath.outer + '" not found.');
         continue;
       }
       


### PR DESCRIPTION
This fixes messages that end up being useless during development :)

```
Running "svn_checkout:make_local" (svn_checkout) task
>> The directory "[object Object]" not found.
```
